### PR TITLE
Bug/catchemall disablecommandfix

### DIFF
--- a/Common/src/main/kotlin/io/github/sirmustfailalot/Config.kt
+++ b/Common/src/main/kotlin/io/github/sirmustfailalot/Config.kt
@@ -156,9 +156,7 @@ object Config {
     fun toggleCatchEmAllMode(playerName: String, toggle: Boolean): Boolean {
         val p = ensurePlayer(playerName)
         write {
-            // ensurePlayer() already created it.data.player[playerName]
             it.player[playerName]!!.catchEmAllMode = toggle
-            logger.info("Player $playerName is now in CatchEmAll mode: $toggle")
         }
         return true
     }

--- a/Common/src/main/kotlin/io/github/sirmustfailalot/commands/PlayerCatchEmAll.kt
+++ b/Common/src/main/kotlin/io/github/sirmustfailalot/commands/PlayerCatchEmAll.kt
@@ -31,11 +31,12 @@ object PlayerCatchEmAll : PAPlayerSubcommand {
                      1
                 }
             )
-            .then(literal("disabled"))
+            .then(literal("disabled")
                 .executes { ctx ->
                     val player = executingPlayerNameOrFail(ctx) ?: return@executes 0
                     toggleCatchEmAllMode(player, false)
                     ctx.source.sendSuccess({ Component.literal("[Project Ash] CatchEmAll: DISABLED").withStyle(ChatFormatting.RED) }, false)
                     1
                 }
+            )
 }


### PR DESCRIPTION
Sourced from "[Bug] CatchEmAll: Disabled Command not working"

The issue was due to a closing bracket being done too early, breaking the command function and resulting in the config function not running.