### PR TITLE
Enchancement/server blacklist features

### DIFF
--- a/Common/src/main/kotlin/io/github/sirmustfailalot/commands/ProjectAshCommand.kt
+++ b/Common/src/main/kotlin/io/github/sirmustfailalot/commands/ProjectAshCommand.kt
@@ -16,7 +16,8 @@ object ProjectAshCommand {
         ServerShinyChecks,
         ServerCheckUnknownSpawns,
         ServerLabelChecks,
-        ServerSpecialChecks
+        ServerSpecialChecks,
+        ServerBlacklistChecks
     )
 
     private val playerSubs: List<PAPlayerSubcommand> = listOf(

--- a/Common/src/main/kotlin/io/github/sirmustfailalot/commands/ServerBlacklistChecks.kt
+++ b/Common/src/main/kotlin/io/github/sirmustfailalot/commands/ServerBlacklistChecks.kt
@@ -1,0 +1,130 @@
+package io.github.sirmustfailalot.projectash.commands
+
+import com.mojang.brigadier.arguments.BoolArgumentType
+import com.mojang.brigadier.arguments.StringArgumentType
+import io.github.sirmustfailalot.projectash.config.Config
+import com.mojang.brigadier.builder.LiteralArgumentBuilder
+import com.mojang.brigadier.suggestion.SuggestionProvider
+import net.minecraft.commands.CommandSourceStack
+import net.minecraft.commands.Commands.literal
+import net.minecraft.commands.Commands.argument
+import net.minecraft.network.chat.Component
+
+object ServerBlacklistChecks : PAServerSubcommand {
+    // Suggest all species; prefer pulling from sprites for UX alignment.
+    private val SPECIES_SUGGESTER: SuggestionProvider<CommandSourceStack> =
+        SuggestionProvider { _, builder ->
+            val species = if (Config.data.sprites.isNotEmpty())
+                Config.data.sprites.keys
+                    .map { it.substringBefore(':').substringBefore('/').substringBefore('_') }
+            else
+                listOf("shuckle")
+
+            species.distinct().sorted().forEach { builder.suggest(it.lowercase()) }
+            builder.buildFuture()
+        }
+
+    // Suggest booleans with 'false' first (since it’s our default)
+    private val BOOL_SUGGESTER: SuggestionProvider<CommandSourceStack> =
+        SuggestionProvider { _, b -> b.suggest("false"); b.suggest("true"); b.buildFuture() }
+
+    override fun build(): LiteralArgumentBuilder<CommandSourceStack> =
+        literal("Blacklist")
+            // /ProjectAsh Server Special Check
+            .then(literal("Check").executes { ctx ->
+                val rules = Config.getServerBlacklistRules()
+                if (rules.isEmpty()) {
+                    ctx.source.sendSuccess({ Component.literal("Server blacklist targets: (none)") }, false)
+                    1
+                } else {
+                    val lines = buildString {
+                        appendLine("Server blacklist targets:")
+                        rules.forEachIndexed { i, r ->
+                            appendLine("  ${i + 1}. ${r.speciesName}  shinyOnly=${r.shinyCheck}")
+                        }
+                    }
+                    ctx.source.sendSuccess({ Component.literal(lines.trimEnd()) }, false)
+                    1
+                }
+            })
+            // /Projectash Server Blacklist Clear
+            .then(literal("Clear")
+                .executes { ctx ->
+                    val clearRules = Config.clearServerBlacklistRules()
+                    if (clearRules) {
+                        ctx.source.sendSuccess({ Component.literal("[Project Ash] Server Blacklist Cleared!") }, true)
+                        1
+                    } else {
+                        ctx.source.sendFailure(Component.literal("[Project Ash] Server Blacklist Failed to Clear!"))
+                        0
+                    }
+                })
+            // /ProjectAsh Server Special Add <species> [shinyOnly]
+            .then(literal("Add")
+                .then(argument("species", StringArgumentType.word())
+                    .suggests(SPECIES_SUGGESTER)
+                    .then(argument("shinyOnly", BoolArgumentType.bool())
+                        .suggests(BOOL_SUGGESTER)
+                        .executes { ctx ->
+                            val species = StringArgumentType.getString(ctx, "species")
+                            val shinyOnly = BoolArgumentType.getBool(ctx, "shinyOnly")
+                            if (Config.addServerBlacklistRule(species, shinyOnly)) {
+                                ctx.source.sendSuccess({
+                                    Component.literal("Added: ${species.lowercase()}  shinyOnly=$shinyOnly")
+                                }, true)
+                                1
+                            } else {
+                                ctx.source.sendFailure(Component.literal("No change: already present or invalid."))
+                                0
+                            }
+                        }))
+                .executes { ctx ->
+                    val species = StringArgumentType.getString(ctx, "species")
+                    val shinyOnly = false
+                    if (Config.addServerBlacklistRule(species, shinyOnly)) {
+                        ctx.source.sendSuccess({
+                            Component.literal("Added: ${species.lowercase()}  shinyOnly=$shinyOnly (default)")
+                        }, true)
+                        1
+                    } else {
+                        ctx.source.sendFailure(Component.literal("No change: already present or invalid."))
+                        0
+                    }
+                }
+            )
+            // /ProjectAsh Server Special Remove <species> [shinyOnly]
+            .then(literal("Remove")
+                .then(argument("species", StringArgumentType.word())
+                    .suggests(SPECIES_SUGGESTER)
+                    // Explicit shinyOnly
+                    .then(argument("shinyOnly", BoolArgumentType.bool())
+                        .suggests(BOOL_SUGGESTER)
+                        .executes { ctx ->
+                            val species = StringArgumentType.getString(ctx, "species")
+                            val shinyOnly = BoolArgumentType.getBool(ctx, "shinyOnly")
+                            if (Config.removeServerBlacklistRule(species, shinyOnly)) {
+                                ctx.source.sendSuccess({
+                                    Component.literal("Removed: ${species.lowercase()}  shinyOnly=$shinyOnly")
+                                }, true)
+                                1
+                            } else {
+                                ctx.source.sendFailure(Component.literal("No change: not present or invalid."))
+                                0
+                            }
+                        }))
+                // Default shinyOnly=false if omitted
+                .executes { ctx ->
+                    val species = StringArgumentType.getString(ctx, "species")
+                    val shinyOnly = false
+                    if (Config.removeServerBlacklistRule(species, shinyOnly)) {
+                        ctx.source.sendSuccess({
+                            Component.literal("Removed: ${species.lowercase()}  shinyOnly=$shinyOnly (default)")
+                        }, true)
+                        1
+                    } else {
+                        ctx.source.sendFailure(Component.literal("No change: not present or invalid."))
+                        0
+                    }
+                }
+            )
+}

--- a/Common/src/main/kotlin/io/github/sirmustfailalot/commands/ServerBlacklistChecks.kt
+++ b/Common/src/main/kotlin/io/github/sirmustfailalot/commands/ServerBlacklistChecks.kt
@@ -40,7 +40,7 @@ object ServerBlacklistChecks : PAServerSubcommand {
                     val lines = buildString {
                         appendLine("Server blacklist targets:")
                         rules.forEachIndexed { i, r ->
-                            appendLine("  ${i + 1}. ${r.speciesName}  shinyOnly=${r.shinyCheck}")
+                            appendLine("  ${i + 1}. ${r.speciesName} includeShiny=${r.shinyCheck}")
                         }
                     }
                     ctx.source.sendSuccess({ Component.literal(lines.trimEnd()) }, false)
@@ -63,14 +63,14 @@ object ServerBlacklistChecks : PAServerSubcommand {
             .then(literal("Add")
                 .then(argument("species", StringArgumentType.word())
                     .suggests(SPECIES_SUGGESTER)
-                    .then(argument("shinyOnly", BoolArgumentType.bool())
+                    .then(argument("includeShiny", BoolArgumentType.bool())
                         .suggests(BOOL_SUGGESTER)
                         .executes { ctx ->
                             val species = StringArgumentType.getString(ctx, "species")
-                            val shinyOnly = BoolArgumentType.getBool(ctx, "shinyOnly")
+                            val shinyOnly = BoolArgumentType.getBool(ctx, "includeShiny")
                             if (Config.addServerBlacklistRule(species, shinyOnly)) {
                                 ctx.source.sendSuccess({
-                                    Component.literal("Added: ${species.lowercase()}  shinyOnly=$shinyOnly")
+                                    Component.literal("Added: ${species.lowercase()}  includeShiny=$shinyOnly")
                                 }, true)
                                 1
                             } else {
@@ -83,7 +83,7 @@ object ServerBlacklistChecks : PAServerSubcommand {
                     val shinyOnly = false
                     if (Config.addServerBlacklistRule(species, shinyOnly)) {
                         ctx.source.sendSuccess({
-                            Component.literal("Added: ${species.lowercase()}  shinyOnly=$shinyOnly (default)")
+                            Component.literal("Added: ${species.lowercase()}  includeShiny=$shinyOnly (default)")
                         }, true)
                         1
                     } else {
@@ -97,14 +97,14 @@ object ServerBlacklistChecks : PAServerSubcommand {
                 .then(argument("species", StringArgumentType.word())
                     .suggests(SPECIES_SUGGESTER)
                     // Explicit shinyOnly
-                    .then(argument("shinyOnly", BoolArgumentType.bool())
+                    .then(argument("includeShiny", BoolArgumentType.bool())
                         .suggests(BOOL_SUGGESTER)
                         .executes { ctx ->
                             val species = StringArgumentType.getString(ctx, "species")
-                            val shinyOnly = BoolArgumentType.getBool(ctx, "shinyOnly")
+                            val shinyOnly = BoolArgumentType.getBool(ctx, "includeShiny")
                             if (Config.removeServerBlacklistRule(species, shinyOnly)) {
                                 ctx.source.sendSuccess({
-                                    Component.literal("Removed: ${species.lowercase()}  shinyOnly=$shinyOnly")
+                                    Component.literal("Removed: ${species.lowercase()}  includeShiny=$shinyOnly")
                                 }, true)
                                 1
                             } else {

--- a/Common/src/main/kotlin/io/github/sirmustfailalot/config/Config.kt
+++ b/Common/src/main/kotlin/io/github/sirmustfailalot/config/Config.kt
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory
 import java.io.File
 
 // ── Types ─────────────────────────────────────────────────────────────────────
-data class SpecialRule(
+data class PokeRule(
     var speciesName: String = "shuckle",
     var shinyCheck: Boolean = false
 )
@@ -33,13 +33,14 @@ data class ServerRule(
     var perfectCheck: Boolean = false,
     var shinyCheck: Boolean = true,
     var labelCheck: List<String> = listOf("Legendary", "Ultra Beast", "Mythical", "Paradox"),
-    var specialCheck: List<SpecialRule> = emptyList()
+    var specialCheck: List<PokeRule> = emptyList(),
+    var blacklistCheck: List<PokeRule> = emptyList()
 )
 
 data class PlayerRule(
     var catchEmAllMode: CatchEmAllRule = CatchEmAllRule(),
     var enabled: Boolean = true,
-    var specialCheck: MutableList<SpecialRule> = mutableListOf()
+    var specialCheck: MutableList<PokeRule> = mutableListOf()
 )
 
 data class ConfigData(
@@ -136,11 +137,44 @@ object Config {
         return true
     }
 
-    fun getServerSpecialRules(): List<SpecialRule> = Config.data.server.specialCheck
+    fun getServerSpecialRules(): List<PokeRule> = Config.data.server.specialCheck
 
     fun clearServerSpecialRules(): Boolean {
         if (data.server.specialCheck.isEmpty()) return false
         write { it.server.specialCheck = emptyList() }   // keep server list immutable
+        return true
+    }
+
+    fun addServerBlacklistRule(species: String, shinyOnly: Boolean): Boolean {
+        val rule = canonicalRule(species, shinyOnly)
+        // no-op if already present
+        if (Config.data.server.blacklistCheck.any { it == rule }) return false
+
+        write {
+            val next = it.server.blacklistCheck.toMutableList()
+            next.add(rule)
+            it.server.blacklistCheck = next
+        }
+        return true
+    }
+
+    fun removeServerBlacklistRule(species: String, shinyOnly: Boolean): Boolean {
+        val rule = canonicalRule(species, shinyOnly)
+        if (!Config.data.server.blacklistCheck.contains(rule)) return false
+
+        write {
+            val next = it.server.blacklistCheck.toMutableList()
+            next.remove(rule)
+            it.server.blacklistCheck = next
+        }
+        return true
+    }
+
+    fun getServerBlacklistRules(): List<PokeRule> = Config.data.server.blacklistCheck
+
+    fun clearServerBlacklistRules(): Boolean {
+        if (data.server.blacklistCheck.isEmpty()) return false
+        write { it.server.blacklistCheck = emptyList() }   // keep server list immutable
         return true
     }
 
@@ -198,7 +232,7 @@ object Config {
         return true
     }
 
-    fun getPlayerSpecialRules(playerName: String): List<SpecialRule> =
+    fun getPlayerSpecialRules(playerName: String): List<PokeRule> =
         (Config.data.player[playerName] ?: PlayerRule()).specialCheck
 
     fun setPlayerSpecialCheck(name: String, enabled: Boolean) = write {
@@ -227,7 +261,7 @@ object Config {
     /** Make a canonical rule for reliable equality/contains/remove operations. */
     private fun norm(s: String) = s.trim().lowercase()
     private fun canonicalRule(species: String, shinyOnly: Boolean) =
-        SpecialRule(
+        PokeRule(
             speciesName = norm(species),
             shinyCheck = shinyOnly
         )

--- a/Common/src/main/kotlin/io/github/sirmustfailalot/pipeline/RuleEngine.kt
+++ b/Common/src/main/kotlin/io/github/sirmustfailalot/pipeline/RuleEngine.kt
@@ -24,49 +24,54 @@ object RuleEngine {
         val logger = LoggerFactory.getLogger("ProjectAsh")
         val result = RuleEvaluationResult()
 
-        // SERVER RULES
-        // Check Allowed Spawn Types
-        if (Config.data.server.checkUnknownSpawns && pokeGlance.spawnSource == "Unknown") {
-            result.discordCriteria.isServerAllowedSpawn = true
-        } else if (pokeGlance.spawnSource == "Known" || pokeGlance.spawnSource == "Egg") {
-            result.discordCriteria.isServerAllowedSpawn = true
-        } else {
-            result.discordCriteria.isServerAllowedSpawn = false
+        val isServerBlacklist = Config.data.server.blacklistCheck.any {
+            it.speciesName.equals(pokeGlance.species, ignoreCase = true) &&
+                    (!it.shinyCheck || pokeGlance.isShiny)
         }
-
-        // Check Shiny Spawns
-        if ( Config.data.server.shinyCheck && pokeGlance.isShiny ) {
-            result.discordCriteria.isServerMessage = true
-            result.discordCriteria.serverLabels.add("Shiny")
-            result.discordCriteria.serverRules.add("Shiny Rule")
-        }
-
-        // Check Perfect IVs Hatches
-        if (( pokeGlance.spawnSource == "Egg" || Config.data.server.perfectCheck ) && pokeGlance.isPerfectIV) {
-            result.discordCriteria.isServerMessage = true
-            result.discordCriteria.serverLabels.add("Perfect")
-            result.discordCriteria.serverRules.add("Perfect Rule")
-        }
-
-        // Check Label Spawns
-        val serverLabels = Config.data.server.labelCheck
-        val hasServerLabel = serverLabels.firstOrNull() { it in pokeGlance.hasLabels} ?: ""
-        if ( pokeGlance.spawnSource != "Egg" && hasServerLabel != "" ) {
-            result.discordCriteria.isServerMessage = true
-            result.discordCriteria.serverLabels.add(hasServerLabel)
-            result.discordCriteria.serverRules.add("Label Rule")
-        }
-
-        if (pokeGlance.spawnSource != "Egg") {
-            // Check Special Spawns
-            val isServerSpecial = Config.data.server.specialCheck.any {
-                it.speciesName.equals(pokeGlance.species, ignoreCase = true) &&
-                        (!it.shinyCheck || pokeGlance.isShiny)
+        if (!isServerBlacklist) {
+            // Check Allowed Spawn Types
+            if (Config.data.server.checkUnknownSpawns && pokeGlance.spawnSource == "Unknown") {
+                result.discordCriteria.isServerAllowedSpawn = true
+            } else if (pokeGlance.spawnSource == "Known" || pokeGlance.spawnSource == "Egg") {
+                result.discordCriteria.isServerAllowedSpawn = true
+            } else {
+                result.discordCriteria.isServerAllowedSpawn = false
             }
-            if (isServerSpecial) {
+
+            // Check Shiny Spawns
+            if (Config.data.server.shinyCheck && pokeGlance.isShiny) {
                 result.discordCriteria.isServerMessage = true
-                result.discordCriteria.serverLabels.add("Special")
-                result.discordCriteria.serverRules.add("Special Rule")
+                result.discordCriteria.serverLabels.add("Shiny")
+                result.discordCriteria.serverRules.add("Shiny Rule")
+            }
+
+            // Check Perfect IVs Hatches
+            if ((pokeGlance.spawnSource == "Egg" || Config.data.server.perfectCheck) && pokeGlance.isPerfectIV) {
+                result.discordCriteria.isServerMessage = true
+                result.discordCriteria.serverLabels.add("Perfect")
+                result.discordCriteria.serverRules.add("Perfect Rule")
+            }
+
+            // Check Label Spawns
+            val serverLabels = Config.data.server.labelCheck
+            val hasServerLabel = serverLabels.firstOrNull() { it in pokeGlance.hasLabels } ?: ""
+            if (pokeGlance.spawnSource != "Egg" && hasServerLabel != "") {
+                result.discordCriteria.isServerMessage = true
+                result.discordCriteria.serverLabels.add(hasServerLabel)
+                result.discordCriteria.serverRules.add("Label Rule")
+            }
+
+            if (pokeGlance.spawnSource != "Egg") {
+                // Check Special Spawns
+                val isServerSpecial = Config.data.server.specialCheck.any {
+                    it.speciesName.equals(pokeGlance.species, ignoreCase = true) &&
+                            (!it.shinyCheck || pokeGlance.isShiny)
+                }
+                if (isServerSpecial) {
+                    result.discordCriteria.isServerMessage = true
+                    result.discordCriteria.serverLabels.add("Special")
+                    result.discordCriteria.serverRules.add("Special Rule")
+                }
             }
         }
 

--- a/Common/src/main/kotlin/io/github/sirmustfailalot/pipeline/RuleEngine.kt
+++ b/Common/src/main/kotlin/io/github/sirmustfailalot/pipeline/RuleEngine.kt
@@ -26,8 +26,12 @@ object RuleEngine {
 
         val isServerBlacklist = Config.data.server.blacklistCheck.any {
             it.speciesName.equals(pokeGlance.species.replace(" ", "-"), ignoreCase = true) &&
-                    (!it.shinyCheck || pokeGlance.isShiny)
+            (
+                it.shinyCheck ||               // blacklist both normal + shiny
+                (!it.shinyCheck && !pokeGlance.isShiny) // blacklist only normal
+            )
         }
+
         if (!isServerBlacklist) {
             // Check Allowed Spawn Types
             if (Config.data.server.checkUnknownSpawns && pokeGlance.spawnSource == "Unknown") {

--- a/Common/src/main/kotlin/io/github/sirmustfailalot/pipeline/RuleEngine.kt
+++ b/Common/src/main/kotlin/io/github/sirmustfailalot/pipeline/RuleEngine.kt
@@ -25,7 +25,7 @@ object RuleEngine {
         val result = RuleEvaluationResult()
 
         val isServerBlacklist = Config.data.server.blacklistCheck.any {
-            it.speciesName.equals(pokeGlance.species, ignoreCase = true) &&
+            it.speciesName.equals(pokeGlance.species.replace(" ", "-"), ignoreCase = true) &&
                     (!it.shinyCheck || pokeGlance.isShiny)
         }
         if (!isServerBlacklist) {
@@ -54,10 +54,10 @@ object RuleEngine {
 
             // Check Label Spawns
             val serverLabels = Config.data.server.labelCheck
-            val hasServerLabel = serverLabels.firstOrNull() { it in pokeGlance.hasLabels } ?: ""
-            if (pokeGlance.spawnSource != "Egg" && hasServerLabel != "") {
+            val hasServerLabel = serverLabels.firstOrNull() { it.lowercase() in pokeGlance.hasLabels.lowercase()} ?: ""
+            if ( pokeGlance.spawnSource != "Egg" && hasServerLabel != "" ) {
                 result.discordCriteria.isServerMessage = true
-                result.discordCriteria.serverLabels.add(hasServerLabel)
+                result.discordCriteria.serverLabels.add(pokeGlance.hasLabels)
                 result.discordCriteria.serverRules.add("Label Rule")
             }
 

--- a/Common/src/main/kotlin/io/github/sirmustfailalot/pipeline/RuleEngine.kt
+++ b/Common/src/main/kotlin/io/github/sirmustfailalot/pipeline/RuleEngine.kt
@@ -24,49 +24,54 @@ object RuleEngine {
         val logger = LoggerFactory.getLogger("ProjectAsh")
         val result = RuleEvaluationResult()
 
-        // SERVER RULES
-        // Check Allowed Spawn Types
-        if (Config.data.server.checkUnknownSpawns && pokeGlance.spawnSource == "Unknown") {
-            result.discordCriteria.isServerAllowedSpawn = true
-        } else if (pokeGlance.spawnSource == "Known" || pokeGlance.spawnSource == "Egg") {
-            result.discordCriteria.isServerAllowedSpawn = true
-        } else {
-            result.discordCriteria.isServerAllowedSpawn = false
+        val isServerBlacklist = Config.data.server.blacklistCheck.any {
+            it.speciesName.equals(pokeGlance.species, ignoreCase = true) &&
+                    (!it.shinyCheck || pokeGlance.isShiny)
         }
-
-        // Check Shiny Spawns
-        if ( Config.data.server.shinyCheck && pokeGlance.isShiny ) {
-            result.discordCriteria.isServerMessage = true
-            result.discordCriteria.serverLabels.add("Shiny")
-            result.discordCriteria.serverRules.add("Shiny Rule")
-        }
-
-        // Check Perfect IVs Hatches
-        if (( pokeGlance.spawnSource == "Egg" || Config.data.server.perfectCheck ) && pokeGlance.isPerfectIV) {
-            result.discordCriteria.isServerMessage = true
-            result.discordCriteria.serverLabels.add("Perfect")
-            result.discordCriteria.serverRules.add("Perfect Rule")
-        }
-
-        // Check Label Spawns
-        val serverLabels = Config.data.server.labelCheck
-        val hasServerLabel = serverLabels.firstOrNull() { it.lowercase() in pokeGlance.hasLabels.lowercase()} ?: ""
-        if ( pokeGlance.spawnSource != "Egg" && hasServerLabel != "" ) {
-            result.discordCriteria.isServerMessage = true
-            result.discordCriteria.serverLabels.add(pokeGlance.hasLabels)
-            result.discordCriteria.serverRules.add("Label Rule")
-        }
-
-        if (pokeGlance.spawnSource != "Egg") {
-            // Check Special Spawns
-            val isServerSpecial = Config.data.server.specialCheck.any {
-                it.speciesName.equals(pokeGlance.species, ignoreCase = true) &&
-                        (!it.shinyCheck || pokeGlance.isShiny)
+        if (!isServerBlacklist) {
+            // Check Allowed Spawn Types
+            if (Config.data.server.checkUnknownSpawns && pokeGlance.spawnSource == "Unknown") {
+                result.discordCriteria.isServerAllowedSpawn = true
+            } else if (pokeGlance.spawnSource == "Known" || pokeGlance.spawnSource == "Egg") {
+                result.discordCriteria.isServerAllowedSpawn = true
+            } else {
+                result.discordCriteria.isServerAllowedSpawn = false
             }
-            if (isServerSpecial) {
+
+            // Check Shiny Spawns
+            if (Config.data.server.shinyCheck && pokeGlance.isShiny) {
                 result.discordCriteria.isServerMessage = true
-                result.discordCriteria.serverLabels.add("Special")
-                result.discordCriteria.serverRules.add("Special Rule")
+                result.discordCriteria.serverLabels.add("Shiny")
+                result.discordCriteria.serverRules.add("Shiny Rule")
+            }
+
+            // Check Perfect IVs Hatches
+            if ((pokeGlance.spawnSource == "Egg" || Config.data.server.perfectCheck) && pokeGlance.isPerfectIV) {
+                result.discordCriteria.isServerMessage = true
+                result.discordCriteria.serverLabels.add("Perfect")
+                result.discordCriteria.serverRules.add("Perfect Rule")
+            }
+
+            // Check Label Spawns
+            val serverLabels = Config.data.server.labelCheck
+            val hasServerLabel = serverLabels.firstOrNull() { it in pokeGlance.hasLabels } ?: ""
+            if (pokeGlance.spawnSource != "Egg" && hasServerLabel != "") {
+                result.discordCriteria.isServerMessage = true
+                result.discordCriteria.serverLabels.add(hasServerLabel)
+                result.discordCriteria.serverRules.add("Label Rule")
+            }
+
+            if (pokeGlance.spawnSource != "Egg") {
+                // Check Special Spawns
+                val isServerSpecial = Config.data.server.specialCheck.any {
+                    it.speciesName.equals(pokeGlance.species, ignoreCase = true) &&
+                            (!it.shinyCheck || pokeGlance.isShiny)
+                }
+                if (isServerSpecial) {
+                    result.discordCriteria.isServerMessage = true
+                    result.discordCriteria.serverLabels.add("Special")
+                    result.discordCriteria.serverRules.add("Special Rule")
+                }
             }
         }
 


### PR DESCRIPTION
Adds the ability to produce a blacklist for server-wide communications.

This will not impact any filters or announcements that players have configured.