### PR TITLE
Enhancement/catchemallmodes

### DIFF
--- a/Common/src/main/kotlin/io/github/sirmustfailalot/commands/menu/MenuModels.kt
+++ b/Common/src/main/kotlin/io/github/sirmustfailalot/commands/menu/MenuModels.kt
@@ -18,6 +18,7 @@ enum class MenuAction(
     val colour: ChatFormatting
 ) {
     CHECK("Check", "Check", colour = ChatFormatting.YELLOW),
+    UPDATE("Update", "Update", MenuClickMode.SUGGEST, ChatFormatting.BLUE),
     ADD("Add", "Add", MenuClickMode.SUGGEST, ChatFormatting.GREEN),
     REMOVE("Remove", "Remove", MenuClickMode.SUGGEST, ChatFormatting.RED),
     CLEAR("Clear", "Clear", colour = ChatFormatting.DARK_RED),

--- a/Common/src/main/kotlin/io/github/sirmustfailalot/commands/player/PlayerCatchEmAll.kt
+++ b/Common/src/main/kotlin/io/github/sirmustfailalot/commands/player/PlayerCatchEmAll.kt
@@ -1,22 +1,29 @@
 package io.github.sirmustfailalot.projectash.commands.player
 
+import com.mojang.brigadier.arguments.StringArgumentType
 import com.mojang.brigadier.builder.LiteralArgumentBuilder
+import com.mojang.brigadier.context.CommandContext
 import io.github.sirmustfailalot.projectash.commands.PAPlayerSubcommand
 import io.github.sirmustfailalot.projectash.commands.menu.*
 import io.github.sirmustfailalot.projectash.commands.utility.executingPlayerNameOrFail
 import io.github.sirmustfailalot.projectash.commands.utility.prefixedStatus
+import io.github.sirmustfailalot.projectash.config.CatchEmAllType
+import io.github.sirmustfailalot.projectash.commands.utility.parseCatchEmAllFlag
+import io.github.sirmustfailalot.projectash.commands.utility.CommandSuggestions
+import io.github.sirmustfailalot.projectash.commands.utility.neutralMessage
 import io.github.sirmustfailalot.projectash.config.Config
 import net.minecraft.ChatFormatting
 import net.minecraft.commands.CommandSourceStack
 import net.minecraft.commands.Commands.literal
 import net.minecraft.network.chat.Component
+import net.minecraft.commands.Commands.argument
 
 object PlayerCatchEmAll : PAPlayerSubcommand {
     private val section = MenuSection(
         "Player CatchEmAll",
         "/ProjectAsh Player CatchEmAll",
         "/ProjectAsh Player",
-        listOf(MenuAction.CHECK, MenuAction.ENABLE, MenuAction.DISABLE)
+        listOf(MenuAction.CHECK, MenuAction.UPDATE)
     )
     private val localSection = MenuSection(
         "Player CatchEmAll > LocalSpawnsOnly",
@@ -36,8 +43,7 @@ object PlayerCatchEmAll : PAPlayerSubcommand {
                 1
             }
             .then(checkCommand())
-            .then(toggleCommand("Enable", true))
-            .then(toggleCommand("Disable", false))
+            .then(catchEmAllTypeCommand("Update", Config::toggleCatchEmAllModeEnabled))
             .then(localSpawnsOnlyCommand())
 
     private fun checkCommand() = literal("Check").executes { ctx ->
@@ -45,18 +51,59 @@ object PlayerCatchEmAll : PAPlayerSubcommand {
         val rule = Config.ensurePlayer(player).catchEmAllMode
         ctx.source.sendSuccess({
             Component.literal("[Project Ash] CatchEmAll: ")
-                .append(if (rule.enabled) Component.literal("ENABLED").withStyle(ChatFormatting.GREEN) else Component.literal("DISABLED").withStyle(ChatFormatting.RED))
+                .append(if (rule.type.toString() == "DISABLED") Component.literal("DISABLED").withStyle(ChatFormatting.RED) else
+                            if (rule.type.toString() == "LIVINGDEX") Component.literal("LIVINGDEX").withStyle(ChatFormatting.GREEN) else
+                                if (rule.type.toString() == "SHINYDEX") Component.literal("SHINYDEX").withStyle(ChatFormatting.GOLD) else
+                                    if (rule.type.toString() == "EVERYDEX") Component.literal("EVERYDEX").withStyle(ChatFormatting.DARK_RED) else
+                                        if (rule.type.toString() == "FORMDEX") Component.literal("FORMDEX").withStyle(ChatFormatting.BLUE) else
+                                            if (rule.type.toString() == "MASTERLIVINGDEX") Component.literal("MASTERLIVINGDEX").withStyle(ChatFormatting.DARK_PURPLE) else Component.literal(""))
                 .append(Component.literal(" | LocalSpawnsOnly: "))
                 .append(if (rule.localSpawnsOnly) Component.literal("ENABLED").withStyle(ChatFormatting.GREEN) else Component.literal("DISABLED").withStyle(ChatFormatting.RED))
         }, false)
         1
     }
 
-    private fun toggleCommand(name: String, enabled: Boolean) = literal(name).executes { ctx ->
-        val player = executingPlayerNameOrFail(ctx) ?: return@executes 0
-        Config.toggleCatchEmAllModeEnabled(player, enabled)
-        ctx.source.sendSuccess({ prefixedStatus("CatchEmAll", enabled) }, false)
-        1
+    private fun catchEmAllTypeCommand(
+        actionName: String,
+        action: (String, CatchEmAllType) -> Boolean
+    ): LiteralArgumentBuilder<CommandSourceStack> = literal(actionName).then(
+        argument("type", StringArgumentType.word())
+            .suggests(CommandSuggestions.CatchEmAllModes)
+            .executes { ctx ->
+                val flag = parseCatchEmAllFlag(StringArgumentType.getString(ctx, "type"))
+                if (flag == null) {
+                    ctx.source.sendFailure(Component.literal("[Project Ash] CatchEmAll Type must be Disabled, LivingDex, ShinyDex, EveryDex, or FormDex."))
+                    return@executes 0
+                }
+                runAction(ctx, flag as CatchEmAllType, action, actionName)
+            }
+    )
+
+    private fun runAction(
+        ctx: CommandContext<CommandSourceStack>,
+        flag: CatchEmAllType,
+        action: (String, CatchEmAllType) -> Boolean,
+        actionName: String
+    ): Int {
+        val player = executingPlayerNameOrFail(ctx) ?: return 0
+        val changed = action(player, flag)
+        if (changed) {
+            val successMessage = Component.literal("[Project Ash] CatchEmAll has been updated to ")
+                .append(when (flag.toString()) {
+                    "DISABLED" -> Component.literal("DISABLED").withStyle(ChatFormatting.RED)
+                    "LIVINGDEX" -> Component.literal("LIVINGDEX").withStyle(ChatFormatting.GREEN)
+                    "SHINYDEX" -> Component.literal("SHINYDEX").withStyle(ChatFormatting.GOLD)
+                    "EVERYDEX" -> Component.literal("EVERYDEX").withStyle(ChatFormatting.DARK_RED)
+                    "FORMDEX" -> Component.literal("FORMDEX").withStyle(ChatFormatting.BLUE)
+                    "MASTERLIVINGDEX" -> Component.literal("MASTERLIVINGDEX").withStyle(ChatFormatting.DARK_PURPLE)
+                    else -> Component.literal("")
+
+                })
+            ctx.source.sendSuccess({ successMessage }, false)
+        } else {
+            ctx.source.sendSuccess({ neutralMessage("No change for CatchEmAll Mode ($flag).") }, false)
+        }
+        return 1
     }
 
     private fun localSpawnsOnlyCommand() = literal("LocalSpawnsOnly")

--- a/Common/src/main/kotlin/io/github/sirmustfailalot/commands/player/PlayerSpecialChecks.kt
+++ b/Common/src/main/kotlin/io/github/sirmustfailalot/commands/player/PlayerSpecialChecks.kt
@@ -3,6 +3,10 @@ package io.github.sirmustfailalot.projectash.commands.player
 import com.mojang.brigadier.arguments.StringArgumentType
 import com.mojang.brigadier.builder.LiteralArgumentBuilder
 import com.mojang.brigadier.context.CommandContext
+import net.minecraft.commands.CommandSourceStack
+import net.minecraft.commands.Commands.argument
+import net.minecraft.commands.Commands.literal
+import net.minecraft.network.chat.Component
 import io.github.sirmustfailalot.projectash.commands.PAPlayerSubcommand
 import io.github.sirmustfailalot.projectash.commands.menu.*
 import io.github.sirmustfailalot.projectash.commands.utility.CommandSuggestions
@@ -12,10 +16,7 @@ import io.github.sirmustfailalot.projectash.commands.utility.prefixedStatus
 import io.github.sirmustfailalot.projectash.commands.utility.neutralMessage
 import io.github.sirmustfailalot.projectash.config.Config
 import io.github.sirmustfailalot.projectash.config.ShinyFlag
-import net.minecraft.commands.CommandSourceStack
-import net.minecraft.commands.Commands.argument
-import net.minecraft.commands.Commands.literal
-import net.minecraft.network.chat.Component
+
 
 object PlayerSpecialChecks : PAPlayerSubcommand {
     private val section = MenuSection(

--- a/Common/src/main/kotlin/io/github/sirmustfailalot/commands/utility/CommandHelpers.kt
+++ b/Common/src/main/kotlin/io/github/sirmustfailalot/commands/utility/CommandHelpers.kt
@@ -1,6 +1,7 @@
 package io.github.sirmustfailalot.projectash.commands.utility
 
 import com.mojang.brigadier.context.CommandContext
+import io.github.sirmustfailalot.projectash.config.CatchEmAllType
 import io.github.sirmustfailalot.projectash.config.ShinyFlag
 import net.minecraft.commands.CommandSourceStack
 import net.minecraft.network.chat.Component
@@ -20,5 +21,16 @@ fun parseShinyFlag(value: String): ShinyFlag? =
         "include" -> ShinyFlag.INCLUDE
         "exclude" -> ShinyFlag.EXCLUDE
         "only" -> ShinyFlag.ONLY
+        else -> null
+    }
+
+fun parseCatchEmAllFlag(value: String): CatchEmAllType? =
+    when (value.trim().lowercase()) {
+        "disabled" -> CatchEmAllType.DISABLED
+        "livingdex" -> CatchEmAllType.LIVINGDEX
+        "shinydex" -> CatchEmAllType.SHINYDEX
+        "everydex" -> CatchEmAllType.EVERYDEX
+        "formdex" -> CatchEmAllType.FORMDEX
+        "masterlivingdex" -> CatchEmAllType.MASTERLIVINGDEX
         else -> null
     }

--- a/Common/src/main/kotlin/io/github/sirmustfailalot/commands/utility/CommandSuggestions.kt
+++ b/Common/src/main/kotlin/io/github/sirmustfailalot/commands/utility/CommandSuggestions.kt
@@ -57,4 +57,10 @@ object CommandSuggestions {
         }
         return (if (values.isEmpty()) fallbackSpecies else values).distinct().sorted()
     }
+
+    val CatchEmAllModes: SuggestionProvider<CommandSourceStack> = SuggestionProvider { _, builder ->
+        listOf("Disabled", "LivingDex", "ShinyDex", "EveryDex", "FormDex", "MasterLivingDex").forEach(builder::suggest)
+        builder.buildFuture()
+    }
+
 }

--- a/Common/src/main/kotlin/io/github/sirmustfailalot/config/Config.kt
+++ b/Common/src/main/kotlin/io/github/sirmustfailalot/config/Config.kt
@@ -15,7 +15,7 @@ data class PokeRule(
 )
 
 data class CatchEmAllRule(
-    var enabled: Boolean = false,
+    var type: CatchEmAllType = CatchEmAllType.DISABLED,
     var localSpawnsOnly: Boolean = true
 )
 
@@ -28,6 +28,15 @@ enum class ShinyFlag {
     INCLUDE,
     EXCLUDE,
     ONLY
+}
+
+enum class CatchEmAllType {
+    DISABLED,
+    LIVINGDEX,
+    SHINYDEX,
+    EVERYDEX,
+    FORMDEX,
+    MASTERLIVINGDEX
 }
 
 data class ShowcaseRule(
@@ -211,10 +220,10 @@ object Config {
         return playerRule
     }
 
-    fun toggleCatchEmAllModeEnabled(playerName: String, toggle: Boolean): Boolean {
+    fun toggleCatchEmAllModeEnabled(playerName: String, catchEmAllType: CatchEmAllType): Boolean {
         val p = ensurePlayer(playerName)
         write {
-            it.player[playerName]!!.catchEmAllMode.enabled = toggle
+            it.player[playerName]!!.catchEmAllMode.type = catchEmAllType
         }
         return true
     }

--- a/Common/src/main/kotlin/io/github/sirmustfailalot/pipeline/RuleEngine.kt
+++ b/Common/src/main/kotlin/io/github/sirmustfailalot/pipeline/RuleEngine.kt
@@ -3,13 +3,24 @@ package io.github.sirmustfailalot.projectash.pipeline
 import com.cobblemon.mod.common.Cobblemon
 import com.cobblemon.mod.common.api.pokedex.Dexes
 import com.cobblemon.mod.common.api.pokedex.PokedexEntryProgress
+import com.cobblemon.mod.common.api.pokedex.SpeciesDexRecord
+import com.cobblemon.mod.common.api.storage.party.PlayerPartyStore
+import com.cobblemon.mod.common.api.storage.pc.PCStore
 import com.cobblemon.mod.common.pokemon.Pokemon
 import com.cobblemon.mod.common.util.cobblemonResource
+import io.github.sirmustfailalot.projectash.config.CatchEmAllType
 import io.github.sirmustfailalot.projectash.config.Config
 import io.github.sirmustfailalot.projectash.config.ShinyFlag
 import io.github.sirmustfailalot.projectash.subscribers.EventSubscribers.server
+import net.minecraft.resources.ResourceLocation
 import net.minecraft.server.level.ServerPlayer
 import org.slf4j.LoggerFactory
+
+val formDexBlacklist = setOf(
+    ResourceLocation.fromNamespaceAndPath("cobblemon", "spinda"),
+    ResourceLocation.fromNamespaceAndPath("cobblemon", "vivillon"),
+    // Add any others if needed, e.g., "alcremie" (depending on how difficult you want it)
+)
 
 object RuleEngine {
 
@@ -84,9 +95,9 @@ object RuleEngine {
             if (pokeGlance.spawnSource != "Egg") {
                 // CatchEmAll check
                 val catchEmAllEnabled =
-                    Config.data.player[playerName]?.catchEmAllMode?.enabled ?: false
+                    Config.data.player[playerName]?.catchEmAllMode?.type ?: false
 
-                if (catchEmAllEnabled) {
+                if (catchEmAllEnabled != CatchEmAllType.DISABLED) {
                     val requiresPokemon = isNewCatch(
                         pokemon = pokeGlance.pokemon,
                         serverPlayer = player
@@ -126,32 +137,99 @@ object RuleEngine {
         pokemon: Pokemon,
         serverPlayer: ServerPlayer
     ): Boolean {
-        val dex = Cobblemon.playerDataManager.getPokedexData(serverPlayer)
+        val playerName = serverPlayer.scoreboardName
+        val dexType = Config.data.player[playerName]?.catchEmAllMode?.type
+        val playerParty = Cobblemon.storage.getParty(serverPlayer)
+        val playerPC = Cobblemon.storage.getPC(serverPlayer)
 
-        val speciesRecord = dex.getSpeciesRecord(pokemon.species.resourceIdentifier)
-            ?: return true
-
-        val dexEntry = Dexes.dexEntryMap[cobblemonResource("national")]
-            ?.getEntries()
-            ?.firstOrNull { it.speciesId == pokemon.species.resourceIdentifier }
-            ?: return true
-
-        val matchingForm = dexEntry.forms
-            .firstOrNull { it.displayForm.equals(pokemon.form.name, ignoreCase = true) }
-            ?: return true
-
-        return matchingForm.unlockForms.none { unlockFormKey ->
-            val isShinyKey = unlockFormKey.contains("shiny", ignoreCase = true)
-
-            if (pokemon.shiny != isShinyKey) {
-                return@none false
+        val alreadyHave = when (dexType) {
+                CatchEmAllType.LIVINGDEX -> livingDexLogic(pokemon, playerParty, playerPC)
+                CatchEmAllType.SHINYDEX -> if (pokemon.shiny) shinyDexLogic(pokemon, playerParty, playerPC) else true
+                CatchEmAllType.EVERYDEX -> everyDexLogic(serverPlayer, pokemon)
+                CatchEmAllType.FORMDEX -> formDexLogic(pokemon, playerParty, playerPC)
+                CatchEmAllType.MASTERLIVINGDEX -> masterDexLogic(pokemon, playerParty, playerPC)
+                else -> true
             }
 
-            val formRecord = speciesRecord.getFormRecord(unlockFormKey)
-                ?: return@none false
+        return !alreadyHave
+    }
 
-            formRecord.knowledge == PokedexEntryProgress.CAUGHT
+    fun livingDexLogic(
+        pokemon: Pokemon,
+        playerParty: PlayerPartyStore,
+        playerPC: PCStore
+    ): Boolean {
+        val inParty = playerParty.any { it.species == pokemon.species }
+        if (inParty) return true
+
+        return playerPC.any { it.species == pokemon.species }
+    }
+
+    fun shinyDexLogic(
+        pokemon: Pokemon,
+        playerParty: PlayerPartyStore,
+        playerPC: PCStore
+    ): Boolean {
+        val targetSpeciesId = pokemon.species.resourceIdentifier
+        val isShinyMatch = { pcPokemon: Pokemon ->
+            pcPokemon.species.resourceIdentifier == targetSpeciesId && pcPokemon.shiny
         }
+        if (playerParty.any(isShinyMatch)) return true
+        return playerPC.any(isShinyMatch)
+    }
+
+    fun everyDexLogic(player: ServerPlayer, targetPokemon: Pokemon): Boolean {
+        val dex = Cobblemon.playerDataManager.getPokedexData(player)
+        val speciesRecord = dex.getSpeciesRecord(targetPokemon.species.resourceIdentifier)
+            ?: return false
+        val dexEntry = Dexes.dexEntryMap[cobblemonResource("national")]
+            ?.getEntries()
+            ?.firstOrNull { it.speciesId == targetPokemon.species.resourceIdentifier }
+            ?: return false
+        val allUnlockKeys = dexEntry.forms.flatMap { it.unlockForms }
+        return allUnlockKeys.any { unlockFormKey ->
+            val formRecord = speciesRecord.getFormRecord(unlockFormKey)
+            formRecord != null && formRecord.knowledge == PokedexEntryProgress.CAUGHT
+        }
+    }
+
+    fun formDexLogic(
+         pokemon: Pokemon,
+         playerParty: PlayerPartyStore,
+         playerPC: PCStore
+    ): Boolean {
+        val targetSpeciesId = pokemon.species.resourceIdentifier
+        val bypassFormCheck = formDexBlacklist.contains(targetSpeciesId)
+        val isMatch = { pcPokemon: Pokemon ->
+            pcPokemon.species.resourceIdentifier == targetSpeciesId && (
+                    bypassFormCheck ||
+                            pcPokemon.form.name.equals(pokemon.form.name, ignoreCase = true)
+                    )
+        }
+        if (playerParty.any(isMatch)) return true
+        return playerPC.any(isMatch)
+    }
+
+    fun masterDexLogic(
+        pokemon: Pokemon,
+        playerParty: PlayerPartyStore,
+        playerPC: PCStore
+    ): Boolean {
+        val targetSpeciesId = pokemon.species.resourceIdentifier
+        val targetFormName = pokemon.form.name
+        val bypassFormCheck = formDexBlacklist.contains(targetSpeciesId)
+
+        val isExactMatch = { pcPokemon: Pokemon ->
+            pcPokemon.species.resourceIdentifier == targetSpeciesId &&
+                    pcPokemon.shiny == pokemon.shiny && (
+                    bypassFormCheck ||
+                            pcPokemon.form.name.equals(targetFormName, ignoreCase = true)
+                    )
+        }
+
+        val alreadyOwnsVariant = playerParty.any(isExactMatch) || playerPC.any(isExactMatch)
+
+        return alreadyOwnsVariant
     }
 
     private fun shinyFlagMatches(

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 * **Rarity Tier Labels:** Formats announcements using built-in labels for specific groups like `Legendary`, `Mythical`, `Ultra Beast`, and `Paradox`.
 * **Egg Hatch Notifications:** Announces to the community when a player successfully hatches an egg.
 * **Entity Load Catching:** Optional `unknownspawns` tracking logs entities loading directly from world generation/chunk loads.
+* **CatchEmAll Dex Modes:** As a player, chose to enable CatchEmAll and have triggers if a Pokemon that spawns that would contribute to your LivingDex, FormDex, ShinyDex etc.
 
 ### ⚔️ Battle Tracking & Fog of War
 * **In-Game Start Flags:** Automatically prints a announcement when an engagement initializes.
@@ -19,6 +20,33 @@
 * **CobbleTCG Integration** Announce your cool cards within the chat, with the ability to see the card when hovering over the card name. This can be shown off either by pressing the showcase key in hand, or by hovering an item in the inventory.
 * **Pokemon Announcing Integration** When an announcement from pokemon spawns, appear, these will be integrated with showcase! Hover over the species name to see the pokemon sprite.
 * **Cord Teleportation** Enhancing announcements that have cords, these will now have a clickable cord position that will teleport you.
+
+
+### 🏆 Supported Dex Modes
+Enabling CatchEmAll will allow you to chose a dex type to proceed, below are a list of the supported dex and their criteria.
+
+`LIVINGDEX`
+
+Rule: The player must physically own at least one copy of every Pokémon species in their PC or Party.
+Note: This mode does not track shiny status or specific regional forms—any variation of the species counts.
+
+`SHINYDEX`
+
+Rule: The player must physically own a Shiny variant of the Pokémon species in their PC or Party to get credit. Normal versions are ignored.
+
+`EVERYDEX`
+
+Rule: Checks the player's historical Pokédex data. As long as the base species has been caught at least once in their career, they get credit—even if they have since traded or released the Pokémon.
+
+`FORMDEX`
+
+Rule: An advanced Living Dex challenge. The player must physically own a copy of every single regional and seasonal form variation (e.g., Alolan vs. Kantonian, or the different Deerling seasons) in their PC or Party.
+Note: Overwhelming aesthetic patterns like Spinda or Vivillon are excluded to keep the challenge fun.
+
+`MASTERLIVINGDEX`
+
+Rule: The ultimate collector's challenge. To achieve completeness, the player's PC and Party must physically hold both the normal version and the shiny version for every single species and form variation.
+
 ---
 
 ## 📦 Installation
@@ -58,7 +86,7 @@ Running the base `/projectash` command opens a responsive textual wizard. Clicki
 | Function / Subfunction | Description | Command Base | Actions Available / Arguments |
 | :--- | :--- | :--- | :--- |
 | `special` | A custom personal whitelist of target species a player wants to track for themselves. | `/ash player special` | `check`, `enable`, `disable`, `add <species> [shinyFlag]`, `remove <species>`, `clear` |
-| `catchemall` | Tracks form metrics, alerting the player if a spawn matches an entry lacking within their specific form/shiny Pokédex. | `/ash player catchemall` | `check`, `enable`, `disable` |
+| `catchemall` | Tracks form metrics, alerting the player if a spawn matches an entry lacking within their specific form/shiny Pokédex. | `/ash player catchemall` | `check`, `update` |
 | `catchemall / localspawnsonly` | Safeguards tracking by only firing "Catch 'Em All" logs if you are the closest player driving that spawn radius. | `/ash player catchemall localspawnsonly` | `check`, `enable`, `disable` |
 
 ### 👑 Server Admin Commands

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project
-version=1.0.14-1.7
+version=1.0.15-1.7
 group=io.github.sirmustfailalot
 
 # Architectury Versions (The Fix) #1.11-SNAPSHOT


### PR DESCRIPTION
Enabling CatchEmAll will allow you to chose a dex type to proceed, below are a list of the supported dex and their criteria.

LIVINGDEX

Rule: The player must physically own at least one copy of every Pokémon species in their PC or Party. Note: This mode does not track shiny status or specific regional forms—any variation of the species counts.

SHINYDEX

Rule: The player must physically own a Shiny variant of the Pokémon species in their PC or Party to get credit. Normal versions are ignored.

EVERYDEX

Rule: Checks the player's historical Pokédex data. As long as the base species has been caught at least once in their career, they get credit—even if they have since traded or released the Pokémon.

FORMDEX

Rule: An advanced Living Dex challenge. The player must physically own a copy of every single regional and seasonal form variation (e.g., Alolan vs. Kantonian, or the different Deerling seasons) in their PC or Party. Note: Overwhelming aesthetic patterns like Spinda or Vivillon are excluded to keep the challenge fun.

MASTERLIVINGDEX

Rule: The ultimate collector's challenge. To achieve completeness, the player's PC and Party must physically hold both the normal version and the shiny version for every single species and form variation.